### PR TITLE
Fix ArgumentCountError: 3 arguments are required, 1 given

### DIFF
--- a/includes/admin/class-wcmp-admin.php
+++ b/includes/admin/class-wcmp-admin.php
@@ -582,10 +582,9 @@ class WCMP_Admin
                 'id' => self::META_HS_CODE,
                 'label' => __('HS Code', 'woocommerce-myparcelbe'),
                 'description' => sprintf(
-                    __('HS Codes are used for MyParcel world shipments, you can find the appropriate code on the %ssite of the Belgium Customs%s.',
-                        'woocommerce-myparcelbe' , '<a href="http://tarief.douane.nl/arctictariff-public-web/#!/home" target="_blank">',
-                        '</a>'
-                    )
+                    __('HS Codes are used for MyParcel world shipments, you can find the appropriate code on the %ssite of the Belgium Customs%s.', 'woocommerce-myparcelbe')
+                    '<a href="http://tarief.douane.nl/arctictariff-public-web/#!/home" target="_blank">',
+                    '</a>'
                 ),
             ]
         );


### PR DESCRIPTION
On one of my websites I found this error:
Een fout van het type E_ERROR trad op op lijn 587 in het bestand public_html/wp-content/plugins/wc-myparcel-belgium/includes/admin/class-wcmp-admin.php. Foutmelding: Uncaught ArgumentCountError: 3 arguments are required, 1 given in public_html/wp-content/plugins/wc-myparcel-belgium/includes/admin/class-wcmp-admin.php:587
Stack trace:
#0 public_html/wp-content/plugins/wc-myparcel-belgium/includes/admin/class-wcmp-admin.php(587): sprintf('HS Codes are us...')
#1 public_html/wp-includes/class-wp-hook.php(292): WCMP_Admin->productHsCodeField('')