### PR TITLE
hotfix: show orders that are made with 4.1.7

### DIFF
--- a/includes/adapter/delivery-options-from-order-adapter.php
+++ b/includes/adapter/delivery-options-from-order-adapter.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use MyParcelNL\Sdk\src\Adapter\DeliveryOptions\AbstractDeliveryOptionsAdapter;
 use MyParcelNL\Sdk\src\Model\Consignment\AbstractConsignment;
 
-class WCMPBE_DeliveryOptionsFromOrderAdapter extends AbstractDeliveryOptionsAdapter
+class WCMP_DeliveryOptionsFromOrderAdapter extends AbstractDeliveryOptionsAdapter
 {
     /**
      * Creates delivery options but sets most missing data to null instead of default values.
@@ -25,7 +25,7 @@ class WCMPBE_DeliveryOptionsFromOrderAdapter extends AbstractDeliveryOptionsAdap
         $this->date            = $inputData['date'] ?? $adapterDate;
         $this->deliveryType    = $inputData['delivery_type'] ?? $adapterDeliveryType;
         $this->packageType     = $inputData['package_type'] ?? $adapterPackageType;
-        $this->shipmentOptions = new WCMPBE_ShipmentOptionsFromOrderAdapter($originAdapter, $inputData);
+        $this->shipmentOptions = new WCMP_ShipmentOptionsFromOrderAdapter($originAdapter, $inputData);
 
         $hasInputPickupLocation = isset($inputData['pickup_location']) && ! empty($inputData['pickup_location']);
         $this->pickupLocation   = $hasInputPickupLocation

--- a/includes/adapter/shipment-options-from-order-adapter.php
+++ b/includes/adapter/shipment-options-from-order-adapter.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 use MyParcelNL\Sdk\src\Adapter\DeliveryOptions\AbstractDeliveryOptionsAdapter;
 use MyParcelNL\Sdk\src\Adapter\DeliveryOptions\AbstractShipmentOptionsAdapter;
 
-class WCMPBE_ShipmentOptionsFromOrderAdapter extends AbstractShipmentOptionsAdapter
+class WCMP_ShipmentOptionsFromOrderAdapter extends AbstractShipmentOptionsAdapter
 {
     private const DEFAULT_INSURANCE = 0;
 
     /**
-     * WCMPBE_ShipmentOptionsFromOrderAdapter constructor.
+     * WCMP_ShipmentOptionsFromOrderAdapter constructor.
      *
      * @param AbstractDeliveryOptionsAdapter|null $originAdapter
      * @param array                               $inputData

--- a/includes/admin/class-wcmypabe-admin.php
+++ b/includes/admin/class-wcmypabe-admin.php
@@ -908,13 +908,13 @@ class WCMYPABE_Admin
                 $meta = DeliveryOptionsAdapterFactory::create((array) $meta);
             } catch (BadMethodCallException $e) {
                 // create new instance from unknown json data
-                $meta = new WCMPBE_DeliveryOptionsFromOrderAdapter(null, (array) $meta);
+                $meta = new WCMP_DeliveryOptionsFromOrderAdapter(null, (array) $meta);
             }
         }
 
         // Create or update immutable adapter from order with a instanceof DeliveryOptionsAdapter
         if (empty($meta) || ! empty($inputData)) {
-            $meta = new WCMPBE_DeliveryOptionsFromOrderAdapter($meta, $inputData);
+            $meta = new WCMP_DeliveryOptionsFromOrderAdapter($meta, $inputData);
         }
 
         return $meta;

--- a/includes/frontend/class-wcmpbe-checkout.php
+++ b/includes/frontend/class-wcmpbe-checkout.php
@@ -244,12 +244,7 @@ class WCMPBE_Checkout
             foreach (self::getDeliveryOptionsConfigMap($carrier) as $key => $setting) {
                 [$settingName, $function, $addBasePrice] = $setting;
 
-
-
                 $value = $settings->{$function}($carrier . '_' . $settingName);
-                if ($settingName === WCMPBE_Settings::SETTING_CARRIER_DELIVERY_DAYS_WINDOW){
-                    var_dump($value);
-                }
                 if (is_numeric($value) && $this->useTotalPrice() && $addBasePrice) {
                     $value += $chosenShippingMethodPrice;
                 }
@@ -406,7 +401,7 @@ class WCMPBE_Checkout
             /*
              * Create a new DeliveryOptions class from the data.
              */
-            $deliveryOptions = new WCMPBE_DeliveryOptionsFromOrderAdapter(null, $deliveryOptions);
+            $deliveryOptions = new WCMP_DeliveryOptionsFromOrderAdapter(null, $deliveryOptions);
 
             /*
              * Store it in the meta data.

--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,9 @@ function wcmyparcelbe_new_email_text($track_trace_tekst) {
 5. MyParcel BE information on the order details page
 
 == Changelog ==
+= 4.3.4 (2021-05-20) =
+* Fix: CRITICAL error incomplete object in _myparcelbe_delivery_options meta
+
 = 4.3.3 (2021-05-20) =
 * Fix: errors when meta keys are not present in the order
 

--- a/woocommerce-myparcel.php
+++ b/woocommerce-myparcel.php
@@ -4,7 +4,7 @@ Plugin Name: WC MyParcel Belgium
 Plugin URI: https://sendmyparcel.be/
 Description: Export your WooCommerce orders to MyParcel BE (https://sendmyparcel.be/) and print labels directly from the WooCommerce admin
 Author: Richard Perdaan
-Version: 4.3.2
+Version: 4.3.4
 Text Domain: woocommerce-myparcelbe
 
 License: GPLv3 or later
@@ -27,7 +27,7 @@ if (! class_exists('WCMYPABE')) :
         const PHP_VERSION_7_1      = '7.1';
         const PHP_VERSION_REQUIRED = self::PHP_VERSION_7_1;
 
-        public $version = '4.3.3';
+        public $version = '4.3.4';
 
         public $plugin_basename;
 


### PR DESCRIPTION
In old orders the code tries to call WCMPBE_ShipmentOptionsFromOrderAdapter and WCMPBE_ShipmentOptionsFromOrderAdapter but the name has changed.